### PR TITLE
docs: Begin laying the groundwork for a 'how' section regarding egress gateways.

### DIFF
--- a/proposals/10-egress-gateways.md
+++ b/proposals/10-egress-gateways.md
@@ -132,8 +132,8 @@ and if not, document it as an alternative considered.
 **Cons**
 - Implies defining equivalents of parentRefs, listeners, and route attachment.
 
-**Alternative Considered: Mesh Resource**
-- Use a `Mesh`-style resource to express egress policies attached to sidecars, as implemented by some service meshes (for example, [Linkerd’s egress configuration](https://linkerd.io/2-edge/reference/egress-network/)).
+**Alternative Considered: Egress Definition Resource**
+- Use a new resource to define which requests should be considered egress traffic, in order to express egress policies independently of the egress gateway. This follows the model used by some service meshes (for example, [Linkerd’s EgressNetwork resource](https://linkerd.io/2-edge/reference/egress-network/#egressnetwork-semantics)).
 - Allows egress to be expressed at the data-plane level without the need for a Gateway instance.
 
 This proposal focuses on the `Gateway`, `Route` and `Backend` model for egress, but MUST NOT preclude Mesh-based egress models in future work.


### PR DESCRIPTION
This PR introduces the initial “How” section for the Egress Gateways proposal.

It defines a clear model for routing outbound traffic through Kubernetes Gateways and describes how policy and extension points can be applied for both general egress and AI-specific use cases.

Importantly, it opens up discussion around important questions regarding:
  - integration with existing Gateway API resources versus creating new ones.
  - support for policies with varying levels of granularity without relying on known anti-patterns.
  