### PR TITLE
Clarify that the egress proposal is for an L7 explicit proxy

### DIFF
--- a/proposals/10-egress-gateways.md
+++ b/proposals/10-egress-gateways.md
@@ -92,7 +92,7 @@ ingress use case.
 
 ### Reverse-Proxy Egress Model
 
-This proposal focuses on a reverse-proxy egress model, where destinations are explicitly configured. It aims to define:
+This proposal focuses on an L7 explicit proxy egress model, where destinations are explicitly configured and workloads must directly route traffic through the Gateway. It aims to define:
 
 1. Resource model using Gateway + HTTPRoute with an additional resource (e.g. `Backend`) for destinations (Service or FQDN).
 2. Two routing modes: Endpoint (direct) and Parent (gateway chaining).


### PR DESCRIPTION
The question of whether our egress proxy operates at L7 exclusively or also at L3/L4 has large implications for our design choices. As such, we should be explicit about the fact that L3/L4 is out ot scope for the proposal. This keeps the discussion and the specification focused on a more tractable set of problems.